### PR TITLE
Refactor: Simplify BrandLogo Component Props Handling

### DIFF
--- a/src/components/BrandLogo.astro
+++ b/src/components/BrandLogo.astro
@@ -1,12 +1,8 @@
----
-const { width } = Astro.props;
-
-interface Props {
-  width: string;
-}
----
-
-<svg class=`h-auto ${width}` viewBox="0 0 521 226" fill="none">
+<svg
+  {...Astro.props}
+  viewBox="0 0 521 226"
+  fill="none"
+>
   <rect
     width="78.937"
     height="18.485"

--- a/src/components/sections/FooterSection.astro
+++ b/src/components/sections/FooterSection.astro
@@ -25,7 +25,7 @@ const crafted: string = Astro.currentLocale === "fr" ? "Fabriqué par" : "Crafte
     <div class="grid grid-cols-2 gap-6 md:grid-cols-4 lg:grid-cols-5">
       <div class="col-span-full lg:col-span-1">
         <!-- Brand Logo -->
-        <BrandLogo width="w-32" />
+        <BrandLogo class="h-auto w-32" />
       </div>
       <!-- An array of links for Product and Company sections -->
       {

--- a/src/components/sections/Navbar.astro
+++ b/src/components/sections/Navbar.astro
@@ -29,7 +29,7 @@ const homeUrl = Astro.currentLocale === "fr" ? "/fr" : "/";
         href={homeUrl}
         aria-label="Brand"
       >
-        <BrandLogo width="w-24" />
+        <BrandLogo class="h-auto w-24" />
       </a>
       <!-- Collapse toggle for smaller screens -->
       <div class="ml-auto mr-5 md:hidden">


### PR DESCRIPTION
This pull request introduces a refactor to the `BrandLogo` component, simplifying the props handling mechanism by utilizing the spread operator. 

This change enhances flexibility by allowing any passed props (eg.: `class`) to be directly applied to the SVG element.