### PR TITLE
Add VSCode settings for pasting/dropping images into content collection pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ dist/
 # generated types
 .astro/
 .idea/
-.vscode/
 
 # dependencies
 node_modules/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+  // Enable pasting files into a Markdown editor to create Markdown links.
+  "markdown.editor.filePaste.enabled": true,
+
+  // Copy pasted media files into a Markdown editor to the workspace.
+  "markdown.editor.filePaste.copyIntoWorkspace": "mediaFiles",
+
+  // Enable dropping files into a Markdown editor to create Markdown links.
+  "markdown.editor.drop.enabled": true,
+
+  // Copy dropped media files into a Markdown editor to the workspace.
+  "markdown.editor.drop.copyIntoWorkspace": "mediaFiles",
+
+  // Define the destination folder for copied files.
+  "markdown.copyFiles.destination": {
+    "/src/content/**/*": "/src/images/content/${documentBaseName}/"
+  },
+}


### PR DESCRIPTION
This pull request adds a new `.vscode/settings.json` file that includes settings to allow pasting and dropping images directly into content collections in Markdown editors.

> To use the drop feature, you will need to press the `Shift`key while dropping the file into the editor.

This feature enables users to easily create Markdown links with media files and copy them into the workspace.

For example:

Pasting the image `getting-started.png` into src/content/post-1.md will do this:

- Add `![alt text](../../images/content/post-1/getting-started.png)` into the post-1.md file
- Move the image file into `src/images/content/post-1/getting-started.png`