### PR TITLE
Fix invalid JSON in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
       "@scripts/*": ["src/assets/scripts/*"],
       "@styles/*": ["src/assets/styles/*"],
       "@utils/*": ["src/utils/*"]
-    },
+    }
   },
   "include": [".astro/types.d.ts", "**/*"],
   "exclude": ["dist"]


### PR DESCRIPTION
tsconfig.json wasn't valid JSON, which caused an error for me when loading any of the .astro files in Neovim.

Remove the trailing comma to make it valid.