### PR TITLE
Fix: Remove extra slash in structured data URLs for FR contact page

### DIFF
--- a/src/pages/fr/contact.astro
+++ b/src/pages/fr/contact.astro
@@ -18,8 +18,8 @@ const ogTitle = "Nous Contacter | ScrewFast";
   structuredData={{
     "@context": "https://schema.org",
     "@type": "WebPage",
-    "@id": "https://screwfast.uk//fr/contact",
-    url: "https://screwfast.uk//fr/contact",
+    "@id": "https://screwfast.uk/fr/contact",
+    url: "https://screwfast.uk/fr/contact",
     name: "Nous Contacter | ScrewFast",
     description:
       "Vous avez des questions ou souhaitez discuter d'un projet ? Contactez-nous et élaborons ensemble la solution parfaite avec nos outils et services.",


### PR DESCRIPTION
This commit corrects the `@id` and `url` fields in the structured data block of the French contact page. Both fields previously contained a double slash ("//fr/contact") due to incorrect path construction. 

The corrected URLs now consistently use a single forward slash, resolving to "https://screwfast.uk/fr/contact".