### PR TITLE
fix: resolve SEO heading hierarchy issue in modal components

### DIFF
--- a/src/components/ui/forms/LoginModal.astro
+++ b/src/components/ui/forms/LoginModal.astro
@@ -30,11 +30,14 @@ const config = {
       >
         <div class="p-4 sm:p-7">
           <div class="text-center">
-            <h2
+            <div
               class="block text-2xl font-bold text-neutral-800 dark:text-neutral-200"
+              role="heading"
+              aria-level="1"
+              aria-label={config.title}
             >
               {config.title}
-            </h2>
+            </div>
             <p class="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
               {config.subTitle}
               <button

--- a/src/components/ui/forms/RecoverModal.astro
+++ b/src/components/ui/forms/RecoverModal.astro
@@ -29,11 +29,14 @@ const config = {
       >
         <div class="p-4 sm:p-7">
           <div class="text-center">
-            <h2
+            <div
               class="block text-2xl font-bold text-neutral-800 dark:text-neutral-200"
+              role="heading"
+              aria-level="1"
+              aria-label={config.title}
             >
               {config.title}
-            </h2>
+            </div>
             <p class="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
               {config.subTitle}
               <!-- Button that, when clicked, opens the login modal -->

--- a/src/components/ui/forms/RegisterModal.astro
+++ b/src/components/ui/forms/RegisterModal.astro
@@ -29,11 +29,14 @@ const config = {
       >
         <div class="p-4 sm:p-7">
           <div class="text-center">
-            <h2
+            <div
               class="block text-2xl font-bold text-neutral-800 dark:text-neutral-200"
+              role="heading"
+              aria-level="1"
+              aria-label={config.title}
             >
               {config.title}
-            </h2>
+            </div>
             <p class="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
               {config.subTitle}
               <!-- Button to toggle login modal -->


### PR DESCRIPTION
- Replace H2 headings with semantic div elements in login, register, and recovery modals
- Add proper ARIA accessibility attributes (role="heading", aria-level="1", aria-label)
- Prevent modal titles from interfering with main page H1/H2/H3 structure
- Maintain visual styling and accessibility while improving technical SEO
- Fixes critical heading hierarchy issue affecting search engine optimization